### PR TITLE
Fixed small typo. Sprout does not need *rts-out*

### DIFF
--- a/README.org
+++ b/README.org
@@ -62,7 +62,7 @@ When cm-incudine is installed and rts is started the svg file can be
 played in realtime using midi:
 
 #+BEGIN_SRC lisp
-(sprout *myseq* *rts-out*)
+(sprout *myseq*)
 #+END_SRC
 
 **Note:** cm-svg is not a package on its own. It is evaluated within


### PR DESCRIPTION
I was going through this and thought that you might want this to be fixed.